### PR TITLE
Add required property

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ The component is only available as a [controlled component](https://facebook.git
 
 The value you provide in `value` and receive in `onChange` is a flat array of objects from `data`.
 
+## Options
+
+Use `required` to make the component trigger the native error box and prevent the ancestor `form` from submitting:
+
+```ts
+<TreeSelect
+  required
+  />
+```
+
 ## Styling
 
 Default looks on the dropdown are purposefully spartan. You should customize that using CSS and content replacements. There is also some work to improve sticky sections.

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -95,6 +95,7 @@ export default class TreeSelect extends React.Component<Props, State> {
           onAttemptToAddFiltered={() => this.attemptToAddFiltered(items)}
           onFilter={s => this.setState({ filter: s || null })}
           onRemove={onRemove}
+          required={this.props.required && this.props.value.length === 0}
           value={findAll(items, i => i.selected, { skipNestedResults: true })}
         />
         {this.state.focused &&

--- a/src/ValueBox.tsx
+++ b/src/ValueBox.tsx
@@ -15,6 +15,7 @@ export interface Props {
   onAttemptToAddFiltered: () => void;
   onFilter: (s: string) => void;
   onRemove: (item: Item) => void;
+  required?: boolean;
   value: Items;
 };
 
@@ -46,6 +47,7 @@ export default function ValueBox(props: Props) {
         onKeyDown={handleKey(props)}
         onChange={e => props.onFilter(e.target.value)}
         ref={props.inputRef}
+        required={props.required}
       />
     </div>
   </div>

--- a/src/public.ts
+++ b/src/public.ts
@@ -29,6 +29,7 @@ export interface TreeSelectProps {
   data: Item[];
   labelTop?: (level: number) => number;
   onChange: (value: Item[]) => void;
+  required?: boolean;
   styles?: {
     filterInput?: React.CSSProperties;
     valueBox?: React.CSSProperties;


### PR DESCRIPTION
![required](https://user-images.githubusercontent.com/3072458/30150129-88e74ac8-93aa-11e7-8b53-654bbfae6298.gif)

When using TreeSelect in a form with the ```required``` attribute set this will trigger native validation and display error tooltip.